### PR TITLE
Holiday checker

### DIFF
--- a/src/hp_channel_db.erl
+++ b/src/hp_channel_db.erl
@@ -1,4 +1,4 @@
--module(hp_channel_storage).
+-module(hp_channel_db).
 
 -export([get_user_channels/1]).
 

--- a/src/hp_channel_storage.erl
+++ b/src/hp_channel_storage.erl
@@ -1,1 +1,10 @@
 -module(hp_channel_storage).
+
+-export([get_user_channels/1]).
+
+get_user_channels(User) ->
+    [#{
+        id => 1,
+        name => <<"My console channel">>,
+        type => console
+      }].

--- a/src/hp_checker.erl
+++ b/src/hp_checker.erl
@@ -20,8 +20,8 @@
 %% triggered by the interval, export for manual tests
 check_holidays() ->
     io:format("Running holiday checker.~n"),
-    Countries = hp_holiday_storage:countries_with_holiday(),
-    Users = hp_user_storage:get_from_countries(Countries),
+    Countries = hp_holiday_db:countries_with_holiday(),
+    Users = hp_user_db:get_from_countries(Countries),
     %% for now remind when we're already in the holiday
     HolidayDate = erlang:date(),
     lists:foreach(fun (User) -> hp_reminder:send(User, HolidayDate) end, Users),

--- a/src/hp_checker.erl
+++ b/src/hp_checker.erl
@@ -1,0 +1,54 @@
+-module(hp_checker).
+
+-behaviour(gen_server).
+
+-export([start_link/0,
+
+         check_holidays/0,
+
+         init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-define(SERVER, ?MODULE).
+%% TODO make configurable
+-define(INTERVAL, 1000 * 60 * 60).
+
+%% triggered by the interval, export for manual tests
+check_holidays() ->
+    io:format("Running holiday checker.~n"),
+    Countries = hp_holiday_storage:countries_with_holiday(),
+    Users = hp_user_storage:get_from_countries(Countries),
+    %% for now remind when we're already in the holiday
+    HolidayDate = erlang:date(),
+    lists:foreach(fun (User) -> hp_reminder:send(User, HolidayDate) end, Users),
+    ok.
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+init([]) ->
+    {ok, _} = timer:send_interval(?INTERVAL, {check_holidays}),
+    {ok, no_state}.
+
+handle_call(_Request, _From, State) ->
+    {noreply, State}.
+
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+handle_info({check_holidays}, State) ->
+    check_holidays(),
+    {noreply, State};
+
+handle_info(_Msg, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/src/hp_holiday_db.erl
+++ b/src/hp_holiday_db.erl
@@ -1,4 +1,4 @@
--module(hp_holiday_storage).
+-module(hp_holiday_db).
 
 %% will be hardcoded to argentinian holidays for now
 

--- a/src/hp_holiday_db.erl
+++ b/src/hp_holiday_db.erl
@@ -1,14 +1,32 @@
 -module(hp_holiday_db).
 
-%% will be hardcoded to argentinian holidays for now
-
 -export([countries_with_holiday/0,
          countries_with_holiday/1]).
 
+%% TODO take from db or somewhere else
+-define(HOLIDAYS, #{
+          argentina => [{1, 1},
+                        {2, 27},
+                        {2, 28},
+                        {3, 24},
+                        {4, 2},
+                        {4, 13},
+                        {4, 14},
+                        {5, 1},
+                        {5, 25},
+                        {6, 17},
+                        {6, 20},
+                        {7, 9},
+                        {11, 20},
+                        {12, 8},
+                        {12, 25}]
+         }).
+
 %% Get the list of the countries that have a holiday in the given date
-%% FIXME implement
 countries_with_holiday(Date) ->
-    [argentina].
+    {_Y, M, D} = Date,
+    CountryMap = maps:filter(fun (_K, Holidays) -> lists:member({M, D}, Holidays) end, ?HOLIDAYS),
+    maps:keys(CountryMap).
 
 countries_with_holiday() ->
     countries_with_holiday(erlang:date()).

--- a/src/hp_holiday_storage.erl
+++ b/src/hp_holiday_storage.erl
@@ -1,3 +1,14 @@
 -module(hp_holiday_storage).
 
 %% will be hardcoded to argentinian holidays for now
+
+-export([countries_with_holiday/0,
+         countries_with_holiday/1]).
+
+%% Get the list of the countries that have a holiday in the given date
+%% FIXME implement
+countries_with_holiday(Date) ->
+    [argentina].
+
+countries_with_holiday() ->
+    countries_with_holiday(erlang:date()).

--- a/src/hp_reminder.erl
+++ b/src/hp_reminder.erl
@@ -36,9 +36,9 @@ handle_cast({send_reminders, User, HolidayDate}, State) ->
     %% TODO build a more meaningful message,
     Message = "dont forget!",
 
-    Channels = hp_channel_storage:get_user_channels(User),
+    Channels = hp_channel_db:get_user_channels(User),
     AlreadySent = fun (Channel) ->
-                          not hp_reminder_storage:is_already_sent(User, Channel, HolidayDate)
+                          not hp_reminder_db:is_already_sent(User, Channel, HolidayDate)
                   end,
     Pending = lists:filter(AlreadySent, Channels),
     SendFn = fun (Channel) ->
@@ -68,5 +68,5 @@ code_change(_OldVsn, State, _Extra) ->
 get_channel_handler(Channel) ->
     fun (User, HolidayDate, Message) ->
             io:format("This is a holiday reminder: ~p~n", [Message]),
-            hp_reminder_storage:set_sent(User, Channel, HolidayDate)
+            hp_reminder_db:set_sent(User, Channel, HolidayDate)
     end.

--- a/src/hp_reminder.erl
+++ b/src/hp_reminder.erl
@@ -1,0 +1,72 @@
+-module(hp_reminder).
+
+-behaviour(gen_server).
+
+-export([start_link/0,
+
+         send/2,
+
+         init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+send(User, HolidayDate) ->
+    {ok, Pid} = supervisor:start_child(hp_reminder_sup, []),
+    gen_server:cast(Pid, {send_reminders, User, HolidayDate}).
+
+start_link() ->
+    gen_server:start_link(?MODULE, [], []).
+
+init([]) ->
+    {ok, no_state}.
+
+handle_call(_Request, _From, State) ->
+    {noreply, State}.
+
+%% Send the message to each channel the user has configured, dont send the same reminder twice
+%% FIXME may be better to use a different process per each channel
+%% TODO instead of tracking already sent by saving in the db, maybe add another server
+%% that just knows how to send individual messages (and retries on failure)
+%% that could later become a pool of workers, use a table instead of a mailbox, etc
+handle_cast({send_reminders, User, HolidayDate}, State) ->
+    io:format("Sending reminders for user ~p~n", [User]),
+    %% TODO build a more meaningful message,
+    Message = "dont forget!",
+
+    Channels = hp_channel_storage:get_user_channels(User),
+    AlreadySent = fun (Channel) ->
+                          not hp_reminder_storage:is_already_sent(User, Channel, HolidayDate)
+                  end,
+    Pending = lists:filter(AlreadySent, Channels),
+    SendFn = fun (Channel) ->
+                     Handler = get_channel_handler(Channel),
+                     Handler(User, HolidayDate, Message)
+             end,
+    lists:foreach(SendFn, Pending),
+    {noreply, State};
+
+handle_cast(Request, State) ->
+    io:format("Unknown message ~p~n", [Request]),
+    {noreply, State}.
+
+handle_info(_Msg, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%% internal
+
+%% Take the channel config and return a function that sends reminder
+%% through that channel
+get_channel_handler(Channel) ->
+    fun (User, HolidayDate, Message) ->
+            io:format("This is a holiday reminder: ~p~n", [Message]),
+            hp_reminder_storage:set_sent(User, Channel, HolidayDate)
+    end.

--- a/src/hp_reminder_db.erl
+++ b/src/hp_reminder_db.erl
@@ -1,4 +1,4 @@
--module(hp_reminder_storage).
+-module(hp_reminder_db).
 
 -export([is_already_sent/4,
          is_already_sent/3,

--- a/src/hp_reminder_storage.erl
+++ b/src/hp_reminder_storage.erl
@@ -1,0 +1,25 @@
+-module(hp_reminder_storage).
+
+-export([is_already_sent/4,
+         is_already_sent/3,
+         set_sent/4,
+         set_sent/3]).
+
+is_already_sent(User, Channel, HolidayDate, ReminderDate) ->
+    false.
+
+is_already_sent(User, Channel, HolidayDate) ->
+    is_already_sent(User, Channel, HolidayDate, erlang:date()).
+
+set_sent(#{id := UserId}, #{id := ChannelId}, HolidayDate, ReminderDate) ->
+    Data = #{
+      user_id => UserId,
+      channel_id => ChannelId,
+      holiday_date => HolidayDate,
+      reminder_date => ReminderDate
+     },
+    io:format("Setting reminder as sent ~p~n", [Data]),
+    ok.
+
+set_sent(User, Channel, HolidayDate) ->
+    set_sent(User, Channel, HolidayDate, erlang:date()).

--- a/src/hp_reminder_sup.erl
+++ b/src/hp_reminder_sup.erl
@@ -1,0 +1,24 @@
+-module(hp_reminder_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0]).
+
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+init([]) ->
+    {ok, { #{ strategy => simple_one_for_one, intensity => 5, period => 1 },
+           [#{
+               id => hp_reminder,
+               start => {hp_reminder, start_link, []},
+               restart => transient,
+               shutdown => 5000,
+               type => worker,
+               modules => [hp_reminder]
+             }]
+         }}.

--- a/src/hp_sup.erl
+++ b/src/hp_sup.erl
@@ -11,4 +11,21 @@ start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
 init([]) ->
-    {ok, { {one_for_one, 0, 1}, []} }.
+    {ok, { #{ strategy => one_for_one, intensity => 5, period => 1 },
+           [#{
+               id => hp_checker,
+               start => {hp_checker, start_link, []},
+               restart => permanent,
+               shutdown => 5000,
+               type => worker,
+               modules => [hp_checker]
+             },
+            #{
+               id => hp_reminder_sup,
+               start => {hp_reminder_sup, start_link, []},
+               restart => permanent,
+               shutdown => 5000,
+               type => supervisor,
+               modules => [hp_reminder_sup]
+             }]
+         }}.

--- a/src/hp_token_handler.erl
+++ b/src/hp_token_handler.erl
@@ -20,7 +20,7 @@ from_json(Req, State) ->
     #{<<"email">> := Email, <<"password">> := Password} = hp_json:decode(Body),
 
     %% FIXME properly handle unauthorized requests
-    {ok, User} = hp_user_storage:authenticate(Email, Password),
+    {ok, User} = hp_user_db:authenticate(Email, Password),
     {ok, Token} = hp_auth_tokens:encode(User),
 
     %% TODO make sure setting response actually works for POST requests

--- a/src/hp_user_db.erl
+++ b/src/hp_user_db.erl
@@ -1,4 +1,4 @@
--module(hp_user_storage).
+-module(hp_user_db).
 
 -export([create/3,
          authenticate/2,

--- a/src/hp_user_handler.erl
+++ b/src/hp_user_handler.erl
@@ -18,5 +18,5 @@ from_json(Req, State) ->
     {ok, Body, Req2} = cowboy_req:body(Req),
     %% TODO validate required fields, password strong enough
     #{<<"email">> := Email, <<"password">> := Password} = hp_json:decode(Body),
-    {ok, _User} = hp_user_storage:create(Email, Password, argentina),
+    {ok, _User} = hp_user_db:create(Email, Password, argentina),
     {true, Req2, State}.

--- a/src/hp_user_storage.erl
+++ b/src/hp_user_storage.erl
@@ -2,7 +2,9 @@
 
 -export([create/3,
          authenticate/2,
-         get_from_country/1]).
+         get_from_countries/1]).
+
+%% FIXME implement this stuff
 
 create(Email, Password, Country) ->
     {ok, #{email => Email,
@@ -12,5 +14,14 @@ authenticate(Email, Password) ->
     {ok, #{email => <<"user@fake.com">>,
            country => argentina}}.
 
-get_from_country(Country) ->
-    [].
+get_from_countries(Countries) ->
+    [#{
+        id => 1,
+        email => "jesus@example.com",
+        country => argentina
+      },
+     #{
+        id => 2,
+        email => "contoso@example.com",
+        country => argentina
+      }].


### PR DESCRIPTION
added a `hp_checker` gen_server that periodically checks for countries where there's currently a holiday and triggers a reminder for each registered user from that country. There's a simple_one_for_one supervisor of `hp_reminder` workers, that send a message through every channel registered for a given user. All db interactions are still hardcoded.