### PR TITLE
Calendar edit

### DIFF
--- a/priv/ui/src/cljs/holiday_ping_ui/calendar.cljs
+++ b/priv/ui/src/cljs/holiday_ping_ui/calendar.cljs
@@ -26,15 +26,16 @@
          (iterate #(time/plus % (time/days 1)))
          (take-while #(<= % last)))))
 
-;; TODO on click disable holiday or enable and ask for holiday name
 (defn date-button
   [month day holiday? today?]
-  (let [day-number (time/day day)]
+  (let [button (cond
+                 holiday? :button.date-item.is-active
+                 today?   :button.date-item.is-today
+                 :else    :button.date-item)]
     (when (= (time/month day) month)
-      (cond
-        holiday? [:button.date-item.is-active day-number]
-        today?   [:button.date-item.is-today day-number]
-        :else    [:button.date-item day-number]))))
+      [button
+       {:on-click #(re-frame/dispatch [:calendar-select-day day])}
+       (time/day day)])))
 
 (defn day-view
   [month day]

--- a/priv/ui/src/cljs/holiday_ping_ui/db.cljs
+++ b/priv/ui/src/cljs/holiday_ping_ui/db.cljs
@@ -11,4 +11,7 @@
    :holidays-edited        nil
    :channels               nil
    :channel-to-test        nil
-   :calendar-selected-year (time/year (time/today))})
+   :calendar-selected-year (time/year (time/today))
+   :calendar-selected-day  nil
+   :calendar-selected-day-name ""
+   })

--- a/priv/ui/src/cljs/holiday_ping_ui/db.cljs
+++ b/priv/ui/src/cljs/holiday_ping_ui/db.cljs
@@ -7,7 +7,8 @@
    :error-message          nil
    :success-message        nil
    :access-token           nil
-   :holidays               nil
+   :holidays-saved         nil
+   :holidays-edited        nil
    :channels               nil
    :channel-to-test        nil
    :calendar-selected-year (time/year (time/today))})

--- a/priv/ui/src/cljs/holiday_ping_ui/events.cljs
+++ b/priv/ui/src/cljs/holiday_ping_ui/events.cljs
@@ -280,3 +280,39 @@
  :calendar-select-year
  (fn [db [_ year]]
    (assoc db :calendar-selected-year year)))
+
+(re-frame/reg-event-db
+ :calendar-select-day
+ (fn [db [_ day]]
+   (let [holidays (:holidays-edited db)
+         name     (:name (first (filter #(time/= day (:date %)) holidays)))]
+     (-> db
+         (assoc :calendar-selected-day day)
+         (assoc :calendar-selected-day-name name)))))
+
+(re-frame/reg-event-db
+ :calendar-deselect-day
+ (fn [db]
+   (-> db
+       (dissoc :calendar-selected-day)
+       (dissoc :calendar-selected-day-name))))
+
+(re-frame/reg-event-db
+ :calendar-selected-name-change
+ (fn [db [_ name]]
+   (assoc db :calendar-selected-day-name name)))
+
+(re-frame/reg-event-db
+ :holidays-update
+ (fn [db [_ date name]]
+   (let [edited  (:holidays-edited db)
+         removed (remove #(time/= date (:date %)) edited)
+         updated (conj removed {:date date :name name})]
+     (assoc db :holidays-edited updated))))
+
+(re-frame/reg-event-db
+ :holidays-remove
+ (fn [db [_ date]]
+   (let [edited  (:holidays-edited db)
+         removed (remove #(time/= date (:date %)) edited)]
+     (assoc db :holidays-edited removed))))

--- a/priv/ui/src/cljs/holiday_ping_ui/subs.cljs
+++ b/priv/ui/src/cljs/holiday_ping_ui/subs.cljs
@@ -28,7 +28,7 @@
 
 (re-frame/reg-sub
  :next-holiday
- (fn [{holidays :holidays}]
+ (fn [{holidays :holidays-saved}]
    (let [upcoming? #(time/after? (:date %) (time/today))
          next      (first (filter upcoming? holidays))]
      (when next
@@ -72,7 +72,7 @@
 
 (re-frame/reg-sub
  :date-info
- (fn [{holidays :holidays} [_ date]]
+ (fn [{holidays :holidays-edited} [_ date]]
    (let [as-holiday (first (filter #(time/= date (:date %)) holidays))]
      {:today?        (time/= (time/today) date)
       :before-today? (time/before? date (time/today))

--- a/priv/ui/src/cljs/holiday_ping_ui/views.cljs
+++ b/priv/ui/src/cljs/holiday_ping_ui/views.cljs
@@ -251,7 +251,7 @@
 ;;; HOLIDAYS views
 (defn holidays-year-switch
   [current next selected]
-  [:div.field.has-addons.has-addons-centered
+  [:div.field.has-addons
    [:p.control
     [:a.button.is-medium
      (if (= selected current)
@@ -265,6 +265,36 @@
        {:href "#" :on-click #(re-frame/dispatch [:calendar-select-year next])})
      next]]])
 
+(defn holiday-controls
+  [current next selected]
+  [:nav.level
+   [:div.level-left
+    [:div.level-item
+     [:div.level-item [holidays-year-switch current next selected]]]]
+   [:div.level-right
+    [:div.field.is-grouped
+     [:p.control
+      [:a.button.is-danger
+       {:title    "Clear all holidays from the calendar"
+        :href     "#"
+        :on-click #(re-frame/dispatch [:calendar-clear])}
+       [:span "Clear"]
+       [:span.icon.is-small [:i.fa.fa-times]]]]
+     [:p.control
+      [:a.button
+       {:title    "Drop the changes made in the calendar"
+        :href     "#"
+        :on-click #(re-frame/dispatch [:calendar-reset])}
+       [:span "Reset"]
+       [:span.icon.is-small [:i.fa.fa-undo]]]]
+     [:p.control
+      [:a.button.is-success
+       {:title    "Save the changes in the calendar"
+        :href     "#"
+        :on-click #(re-frame/dispatch [:calendar-save])}
+       [:span "Save"]
+       [:span.icon.is-small [:i.fa.fa-check]]]]]]])
+
 (defn holidays-view
   []
   (let [current-year  @(re-frame/subscribe [:current-year])
@@ -274,7 +304,8 @@
      [header-section "Holidays"
       [:p "Select the days of the year for which you want reminders."]]
      [section
-      [holidays-year-switch current-year next-year selected-year]
+      [holiday-controls current-year next-year selected-year]
+      ;; [holidays-year-switch current-year next-year selected-year]
       [:div (when-not (= selected-year current-year) {:hidden true})
        [calendar/year-view current-year]]
       [:div (when-not (= selected-year next-year) {:hidden true})

--- a/priv/ui/src/cljs/holiday_ping_ui/views.cljs
+++ b/priv/ui/src/cljs/holiday_ping_ui/views.cljs
@@ -277,21 +277,21 @@
       [:a.button.is-danger
        {:title    "Clear all holidays from the calendar"
         :href     "#"
-        :on-click #(re-frame/dispatch [:calendar-clear])}
+        :on-click #(re-frame/dispatch [:holidays-clear])}
        [:span "Clear"]
        [:span.icon.is-small [:i.fa.fa-times]]]]
      [:p.control
       [:a.button
        {:title    "Drop the changes made in the calendar"
         :href     "#"
-        :on-click #(re-frame/dispatch [:calendar-reset])}
+        :on-click #(re-frame/dispatch [:holidays-reset])}
        [:span "Reset"]
        [:span.icon.is-small [:i.fa.fa-undo]]]]
      [:p.control
       [:a.button.is-success
        {:title    "Save the changes in the calendar"
         :href     "#"
-        :on-click #(re-frame/dispatch [:calendar-save])}
+        :on-click #(re-frame/dispatch [:holidays-save])}
        [:span "Save"]
        [:span.icon.is-small [:i.fa.fa-check]]]]]]])
 


### PR DESCRIPTION
Adds clear, reset and save buttons to the holiday views, and a modal to set/unset holidays in the calendar and change their names. Fixes #61 

There's a performance issue with the modal input, tracked [here](https://github.com/lambdaclass/holiday_ping/issues/82).