### PR TITLE
resend reminders until found as sent in db

### DIFF
--- a/conf/dev.config
+++ b/conf/dev.config
@@ -5,7 +5,7 @@
                  {token_expiration, 86400},
                  {verification_code_expiration, 300},
                  {password_code_expiration, 300},
-                 {checker_interval, 86400000},
+                 {checker_interval, 900000},
                  {email_enabled, true},
                  {monthly_limits, #{slack => 100,
                                     email => 100,

--- a/src/reminders/remind_router.erl
+++ b/src/reminders/remind_router.erl
@@ -40,13 +40,15 @@ handle_cast({send_reminder, User, Channel, HolidayDate, Message, IsTest}, State)
   lager:debug("Sending reminders for user ~p and channel ~p",
               [UserName, ChannelName]),
 
-  case check_limit(Email, Type) of
+  case check_should_send(Email, Channel) of
     ok ->
       Handler = get_handler(Type),
       case Handler:handle(User, HolidayDate, Config, Message) of
         {ok, SentReminders} -> save_reminders(User, Channel, SentReminders, IsTest);
         Error -> lager:warning(<<"Error sending reminders ~p">>, [Error])
       end;
+    already_sent ->
+      ok;
     limit_exceeded ->
       lager:warning(<<"User ~p exceeded channel limit for type ~p">>,
                     [UserName, Type])
@@ -71,16 +73,30 @@ get_handler(ets) -> ets_channel;
 get_handler(webhook) -> webhook_channel;
 get_handler(email) -> email_channel.
 
+save_reminders(#{email := Email}, #{name := ChannelName}, Targets, IsTest) ->
+  db_reminder:save(Email, ChannelName, Targets, IsTest).
+
+check_should_send(Email, #{name := ChannelName, type := ChannelType}) ->
+  case is_already_sent(Email, ChannelName) of
+    true -> already_sent;
+    false -> check_limit(Email, ChannelType)
+  end.
+
+is_already_sent(Email, ChannelName) ->
+  %% the channels currently return ok if all their reminders were sent, so if
+  %% one exists we can safely assume the entire pack was sent.
+  case db_reminder:sent_count(Email, ChannelName, erlang:date()) of
+    {ok, 0} -> false;
+    {ok, _} -> true
+  end.
+
 check_limit(Email, Type) ->
   ChannelLimits = hp_config:get(monthly_limits),
   case maps:get(Type, ChannelLimits, undefined) of
     Limit when is_integer(Limit), Limit > 0 ->
-      case db_reminder:get_current_count(Email, Type) of
+      case db_reminder:get_monthly_count(Email, Type) of
         {ok, Count} when Count >= Limit -> limit_exceeded;
         _ -> ok
       end;
     _ -> ok
   end.
-
-save_reminders(#{email := Email}, #{name := ChannelName}, Targets, IsTest) ->
-  db_reminder:save(Email, ChannelName, Targets, IsTest).


### PR DESCRIPTION
instead of running once a day, the checker now runs every 15 minutes and checks if a reminder hasn't been already sent for that channel/day. That way the reminder is retried until it's finally sent.

That also fixes the fact that the current day's holidays could be missed if the app was restarted.

fixes #9 