### PR TITLE
Prod https

### DIFF
--- a/conf/dev.config
+++ b/conf/dev.config
@@ -1,5 +1,6 @@
 [
  {holiday_ping, [
+                 {protocol, http},
                  {port, 8001},
                  {token_secret, <<"secret">>},
                  {token_expiration, 86400},

--- a/conf/prod.config
+++ b/conf/prod.config
@@ -1,7 +1,7 @@
 [
  {holiday_ping, [
                  {protocol, https},
-                 {port, 8001},
+                 {port, 443},
                  {certfile, "FIXME!!!"},
                  {keyfile, "FIXME!!!"},
                  {token_secret, <<"FIXME!!!">>},

--- a/conf/prod.config
+++ b/conf/prod.config
@@ -1,7 +1,10 @@
 [
  {holiday_ping, [
+                 {protocol, https},
                  {port, 8001},
-                 {token_secret, <<"FIXME!!!!">>},
+                 {certfile, "FIXME!!!"},
+                 {keyfile, "FIXME!!!"},
+                 {token_secret, <<"FIXME!!!">>},
                  {token_expiration, 86400},
                  {verification_code_expiration, 300},
                  {password_code_expiration, 300},

--- a/conf/test.config
+++ b/conf/test.config
@@ -1,5 +1,6 @@
 [
  {holiday_ping, [
+                 {protocol, http},
                  {port, 8001},
                  {token_secret, <<"secret">>},
                  {token_expiration, 86400},

--- a/src/holiday_ping.app.src
+++ b/src/holiday_ping.app.src
@@ -10,6 +10,7 @@
     sasl,
     lager,
     pgapp,
+    jwt,
     throttle,
     hackney,
     erlpass,

--- a/src/holiday_ping_app.erl
+++ b/src/holiday_ping_app.erl
@@ -30,11 +30,18 @@ start(_StartType, _StartArgs) ->
                                            {"/api/holidays/:country", country_holidays_handler, []},
                                            {'_', cowboy_static, {priv_file, holiday_ping, "/ui/resources/public/index.html"}}]}
                                    ]),
-  cowboy:start_http(my_http_listener, 100, [{port, hp_config:get(port)}],
-                    [{env, [{dispatch, Dispatch}]},
-                     {middlewares, [cowboy_router, throttling_middleware, cowboy_handler]}]
-                   ),
+  start_cowboy(hp_config:get(protocol),
+               [{env, [{dispatch, Dispatch}]},
+                {middlewares, [cowboy_router, throttling_middleware, cowboy_handler]}]),
   hp_sup:start_link().
+
+start_cowboy(http, Options) ->
+  cowboy:start_http(my_http_listener, 100, [{port, hp_config:get(port)}], Options);
+start_cowboy(https, Options) ->
+  cowboy:start_https(my_http_listener, 100,
+                     [{port, hp_config:get(port)},
+                      {certfile, hp_config:get(certfile)},
+                      {keyfile, hp_config:get(keyfile)}], Options).
 
 stop(_State) ->
   ok.


### PR DESCRIPTION
Added an option to start the app with https instead of http, and the relevant configuration to use it with the prod profile. Tested it on the server.

fixes #183 